### PR TITLE
Add option to use an existing database

### DIFF
--- a/init_table/app.py
+++ b/init_table/app.py
@@ -28,7 +28,7 @@ param_path = f'/{env}/canvas_data_2'
 
 api_base_url = os.environ.get('API_BASE_URL', 'https://api-gateway.instructure.com')
 
-namespace = 'canvas'
+namespace = os.environ.get('DB_SCHEMA', 'canvas')
 
 def start(event):
     params = ssm_provider.get_multiple(param_path, max_age=600, decrypt=True)

--- a/init_table/app.py
+++ b/init_table/app.py
@@ -28,8 +28,6 @@ param_path = f'/{env}/canvas_data_2'
 
 api_base_url = os.environ.get('API_BASE_URL', 'https://api-gateway.instructure.com')
 
-namespace = os.environ.get('DB_SCHEMA', 'canvas')
-
 def start(event):
     params = ssm_provider.get_multiple(param_path, max_age=600, decrypt=True)
     dap_client_id = params['dap_client_id']
@@ -41,6 +39,7 @@ def start(event):
     db_name = db_user_secret['dbname']
     db_host = db_user_secret['host']
     db_port = db_user_secret['port']
+    namespace = db_user
 
     conn_str = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}?sslmode=verify-ca&sslrootcert=rds-combined-ca-bundle.pem"
     db_connection = DatabaseConnection(connection_string=conn_str)

--- a/setup/prepare_aurora_db.py
+++ b/setup/prepare_aurora_db.py
@@ -35,7 +35,7 @@ admin_username = admin_secret["username"]
 
 # Get CD2 database user secret
 db_user_secret_arn = stack_outputs["DatabaseUserSecretArn"]
-db_user_secret = json.loads(secrets_client.get_secret_value(SecretId=admin_secret_arn)["SecretString"])
+db_user_secret = json.loads(secrets_client.get_secret_value(SecretId=db_user_secret_arn)["SecretString"])
 db_user_username = db_user_secret["username"]
 
 # Get Aurora cluster ARN

--- a/setup/prepare_aurora_db.py
+++ b/setup/prepare_aurora_db.py
@@ -36,7 +36,7 @@ admin_username = admin_secret["username"]
 # Get CD2 database user secret
 db_user_secret_arn = stack_outputs["DatabaseUserSecretArn"]
 db_user_secret = json.loads(secrets_client.get_secret_value(SecretId=admin_secret_arn)["SecretString"])
-db_user_username = admin_secret["username"]
+db_user_username = db_user_secret["username"]
 
 # Get Aurora cluster ARN
 aurora_cluster_arn = stack_outputs["AuroraClusterArn"]

--- a/sync_table/app.py
+++ b/sync_table/app.py
@@ -30,7 +30,6 @@ db_user_secret_name = os.environ.get("DB_USER_SECRET_NAME")
 admin_secret_arn = os.environ.get("ADMIN_SECRET_ARN")
 param_path = f"/{env}/canvas_data_2"
 api_base_url = os.environ.get("API_BASE_URL", "https://api-gateway.instructure.com")
-namespace = os.environ.get('DB_SCHEMA', 'canvas')
 
 def start(event):
     params = ssm_provider.get_multiple(param_path, max_age=600, decrypt=True)
@@ -44,6 +43,7 @@ def start(event):
     db_name = db_user_secret["dbname"]
     db_host = db_user_secret["host"]
     db_port = db_user_secret["port"]
+    namespace = db_user
 
     conn_str = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}?sslmode=verify-ca&sslrootcert=rds-combined-ca-bundle.pem"
     db_connection = DatabaseConnection(connection_string=conn_str)

--- a/sync_table/app.py
+++ b/sync_table/app.py
@@ -30,7 +30,7 @@ db_user_secret_name = os.environ.get("DB_USER_SECRET_NAME")
 admin_secret_arn = os.environ.get("ADMIN_SECRET_ARN")
 param_path = f"/{env}/canvas_data_2"
 api_base_url = os.environ.get("API_BASE_URL", "https://api-gateway.instructure.com")
-namespace = "canvas"
+namespace = os.environ.get('DB_SCHEMA', 'canvas')
 
 def start(event):
     params = ssm_provider.get_multiple(param_path, max_age=600, decrypt=True)

--- a/template.yaml
+++ b/template.yaml
@@ -1289,13 +1289,18 @@ Resources:
       TargetType: AWS::RDS::DBCluster          
 
 Outputs:
-  AdminSecretArn:
+  DatabaseAdminSecretArn:
     Value: !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn
-    Description: Canvas Data 2 database admin user secret
+    Description: Canvas Data 2 database admin user secret ARN
     Export:
-      Name: !Sub ${ResourcePrefixParameter}-cd2-aurora-admin-secret-arn-${EnvironmentParameter}
+      Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-db-admin-secret-arn
+  DatabaseUserSecretArn:
+    Value: !Ref DatabaseUserSecretCanvas
+    Description: Canvas Data 2 database user secret ARN
+    Export:
+      Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-db-user-secret-arn
   AuroraClusterArn:
     Value: !GetAtt AuroraDatabaseCluster.DBClusterArn
-    Description: The ARN of the Canvas Data 2 Aurora cluster
+    Description: Canvas Data 2 Aurora cluster ARN
     Export:
-      Name: !Sub ${ResourcePrefixParameter}-cd2-aurora-cluster-arn-${EnvironmentParameter}
+      Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-aurora-cluster-arn

--- a/template.yaml
+++ b/template.yaml
@@ -589,7 +589,7 @@ Resources:
             - secretsmanager:GetSecretValue
             Resource:
             - !Ref DatabaseUserSecretCanvas
-            - !If [ExistingDatabase, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]
+            - !If [ExistingDatabaseAdminSecret, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]
       - PolicyName: kms
         PolicyDocument:
           Statement:
@@ -1045,7 +1045,7 @@ Resources:
                         - Name: DB_USER_SECRET_NAME
                           Value: !Ref DatabaseUserSecretCanvas
                         - Name: ADMIN_SECRET_ARN
-                          Value: !If [ExistingDatabase, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]
+                          Value: !If [ExistingDatabaseAdminSecret, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]
                         - Name: DB_CLUSTER_ARN
                           Value: !If [ExistingDatabase, !Ref DatabaseClusterArnParameter, !GetAtt AuroraDatabaseCluster.DBClusterArn]
                   TimeoutSeconds: 43200
@@ -1318,7 +1318,7 @@ Resources:
 
 Outputs:
   DatabaseAdminSecretArn:
-    Value: !If [ExistingDatabase, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]          
+    Value: !If [ExistingDatabaseAdminSecret, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]          
     Description: Canvas Data 2 database admin user secret ARN
     Export:
       Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-db-admin-secret-arn

--- a/template.yaml
+++ b/template.yaml
@@ -259,7 +259,7 @@ Resources:
   DatabaseUserSecretCanvas:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub ${ResourcePrefixParameter}-cd2-db-user-${EnvironmentParameter}-canvas
+      Name: !Sub ${ResourcePrefixParameter}-cd2-db-user-${EnvironmentParameter}-${DatabaseCd2UserParameter}
       Description: Database user for Canvas Data 2 canvas user
       GenerateSecretString:
         SecretStringTemplate: !Sub '{"username": "${DatabaseCd2UserParameter}"}'

--- a/template.yaml
+++ b/template.yaml
@@ -107,6 +107,16 @@ Parameters:
     Type: String
     Description: The ARN for the IAM role creating/updating this stack.
 
+  DatabaseClusterArnParameter:
+    Type: String
+    Description: (Optional) An existing Aurora database cluster ARN. Leave empty to create a new Aurora database cluster.
+    Default: ''
+
+  DatabaseAdminSecretArnParameter:
+    Type: String
+    Description: (Optional) An existing database admin secret ARN. Use default value if DatabaseClusterArnParameter is empty.
+    Default: arn:aws:secretsmanager:region:123456789123:secret:placeholder
+
   DatabaseSecurityGroupParameter:
     Type: String
     Description: (Optional) A security group ID for the database. Leave empty to create a new security group.
@@ -114,7 +124,7 @@ Parameters:
 
   AthenaConnectorParameter:
     Type: String
-    Description: (Optional) Create an Athena connector for PostgreSQL. Default is false.
+    Description: (Optional) Create an Athena connector for PostgreSQL. Default is false. Must be false when values are set for DatabaseAdminSecretArnParameter and DatabaseSecurityGroupParameter.
     AllowedValues: [true, false]
     Default: false
 
@@ -146,6 +156,14 @@ Parameters:
 
 Conditions:
 
+  # Conditions for Bring Your Own Aurora Database Cluster
+  ExistingDatabase: !Not [!Equals [!Ref DatabaseClusterArnParameter, '']]
+  ExistingDatabaseAdminSecret: !Not [!Equals [!Ref DatabaseAdminSecretArnParameter, '']]
+  CreateDatabase: !Not
+    - !Or
+        - Condition: ExistingDatabase
+        - Condition: ExistingDatabaseAdminSecret
+
   # Conditions for Bring Your Own Data Security Group
   ExistingDatabaseSecurityGroup: !Not [!Equals [!Ref DatabaseSecurityGroupParameter, '']]
   CreateDatabaseSecurityGroup: !Equals [!Ref DatabaseSecurityGroupParameter, '']
@@ -161,7 +179,11 @@ Conditions:
   
   # Condition for optional Athena connector
   # Creates an Athena data source allowing CD2 data to be joined with other data sources
-  CreateAthenaConnector: !Equals [true, !Ref AthenaConnectorParameter]
+  # Can only be created if the database is created in this stack.
+  AthenaConnector: !Equals [true, !Ref AthenaConnectorParameter]
+  CreateAthenaConnector: !And
+        - Condition: AthenaConnector
+        - Condition: CreateDatabase
 
 Resources:
 
@@ -276,7 +298,7 @@ Resources:
     Type: AWS::SecretsManager::SecretTargetAttachment
     Properties:
       SecretId: !Ref DatabaseUserSecretCanvas
-      TargetId: !Ref AuroraDatabaseCluster
+      TargetId: !If [ExistingDatabase, !Select [ "6", !Split [ ":" , !Ref DatabaseClusterArnParameter ] ], !Ref AuroraDatabaseCluster]      
       TargetType: AWS::RDS::DBCluster          
 
   DatabaseSubnetGroup:
@@ -324,6 +346,7 @@ Resources:
 
   AuroraDatabaseCluster:
     Type: AWS::RDS::DBCluster
+    Condition: CreateDatabase
     Properties:
       Engine: aurora-postgresql
       EngineVersion: 15.5
@@ -364,6 +387,7 @@ Resources:
 
   AuroraDatabaseInstance:
     Type: AWS::RDS::DBInstance
+    Condition: CreateDatabase
     Properties:
       Engine: aurora-postgresql
       DBInstanceClass: db.serverless
@@ -374,6 +398,7 @@ Resources:
 
   DatabasePostgresqlLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: CreateDatabase
     Properties:
       LogGroupName: !Sub /aws/rds/cluster/${AuroraDatabaseCluster}/postgresql
       RetentionInDays: !Ref LogRetentionParameter
@@ -561,7 +586,7 @@ Resources:
             - secretsmanager:GetSecretValue
             Resource:
             - !Ref DatabaseUserSecretCanvas
-            - !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn
+            - !If [ExistingDatabase, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]
       - PolicyName: kms
         PolicyDocument:
           Statement:
@@ -589,7 +614,7 @@ Resources:
             Action:
             - rds-data:*
             Resource:
-            - !GetAtt AuroraDatabaseCluster.DBClusterArn
+            - !If [ExistingDatabase, !Ref DatabaseClusterArnParameter, !GetAtt AuroraDatabaseCluster.DBClusterArn]
       - PolicyName: state_machine
         PolicyDocument:
           Statement:
@@ -1017,9 +1042,9 @@ Resources:
                         - Name: DB_USER_SECRET_NAME
                           Value: !Ref DatabaseUserSecretCanvas
                         - Name: ADMIN_SECRET_ARN
-                          Value: !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn
+                          Value: !If [ExistingDatabase, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]
                         - Name: DB_CLUSTER_ARN
-                          Value: !GetAtt AuroraDatabaseCluster.DBClusterArn  
+                          Value: !If [ExistingDatabase, !Ref DatabaseClusterArnParameter, !GetAtt AuroraDatabaseCluster.DBClusterArn]
                   TimeoutSeconds: 43200
                   Retry:
                     - ErrorEquals:
@@ -1290,7 +1315,7 @@ Resources:
 
 Outputs:
   DatabaseAdminSecretArn:
-    Value: !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn
+    Value: !If [ExistingDatabase, !Ref DatabaseAdminSecretArnParameter, !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn]          
     Description: Canvas Data 2 database admin user secret ARN
     Export:
       Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-db-admin-secret-arn
@@ -1300,7 +1325,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-db-user-secret-arn
   AuroraClusterArn:
-    Value: !GetAtt AuroraDatabaseCluster.DBClusterArn
+    Value: !If [ExistingDatabase, !Ref DatabaseClusterArnParameter, !GetAtt AuroraDatabaseCluster.DBClusterArn]
     Description: Canvas Data 2 Aurora cluster ARN
     Export:
       Name: !Sub ${AWS::StackName}-${EnvironmentParameter}-aurora-cluster-arn

--- a/template.yaml
+++ b/template.yaml
@@ -112,6 +112,8 @@ Parameters:
     Description: (Optional) An existing Aurora database cluster ARN. Leave empty to create a new Aurora database cluster.
     Default: ''
 
+  # Default value is an ARN because it's referenced in the stack within a conditional statement.
+  # It must resolve as an ARN for the template to be valid.
   DatabaseAdminSecretArnParameter:
     Type: String
     Description: (Optional) An existing database admin secret ARN. Use default value if DatabaseClusterArnParameter is empty.
@@ -157,8 +159,9 @@ Parameters:
 Conditions:
 
   # Conditions for Bring Your Own Aurora Database Cluster
+  # Requires both DatabaseClusterArnParameter and DatabaseAdminSecretArnParameter to be specified
   ExistingDatabase: !Not [!Equals [!Ref DatabaseClusterArnParameter, '']]
-  ExistingDatabaseAdminSecret: !Not [!Equals [!Ref DatabaseAdminSecretArnParameter, '']]
+  ExistingDatabaseAdminSecret: !Not [!Equals [!Ref DatabaseAdminSecretArnParameter, 'arn:aws:secretsmanager:region:123456789123:secret:placeholder']]
   CreateDatabase: !Not
     - !Or
         - Condition: ExistingDatabase
@@ -172,14 +175,14 @@ Conditions:
   ExistingNotificationTopic: !Not [!Equals [!Ref NotificationTopicParameter, '']]
   CreateNotificationTopic: !Equals [!Ref NotificationTopicParameter, '']
 
-  # Condition for CrowdStrike Falcon sensor
+  # Condition for optional CrowdStrike Falcon sensor
   # Configures an additional container task that injects the Falcon sensor into Fargate tasks
   # For more info: https://github.com/CrowdStrike/Container-Security/blob/0d2ae005be852aae403df3feb11e3bf2fd1f5258/aws-ecs/ecs-fargate-guide.md
   ConfigureFalconSensor: !Equals [true, !Ref FalconSensorParameter]
   
-  # Condition for optional Athena connector
+  # Conditions for optional Athena connector
   # Creates an Athena data source allowing CD2 data to be joined with other data sources
-  # Can only be created if the database is created in this stack.
+  # Requires CreateDatabase condition to be true to ensure cluster endpoint and port exist
   AthenaConnector: !Equals [true, !Ref AthenaConnectorParameter]
   CreateAthenaConnector: !And
         - Condition: AthenaConnector

--- a/template.yaml
+++ b/template.yaml
@@ -55,11 +55,6 @@ Parameters:
     Type: String
     Description: Username for the canvas database user.
 
-  DatabaseSchemaParameter:
-    Type: String
-    Description: Target schema for CD2 data.
-    Default: canvas
-
   DatabaseMinCapacityParameter:
     Type: Number
     Description: Serverless Aurora minimum capacity.
@@ -1025,8 +1020,6 @@ Resources:
                           Value: !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn
                         - Name: DB_CLUSTER_ARN
                           Value: !GetAtt AuroraDatabaseCluster.DBClusterArn  
-                        - Name: DB_SCHEMA
-                          Value: !Ref DatabaseSchemaParameter
                   TimeoutSeconds: 43200
                   Retry:
                     - ErrorEquals:
@@ -1085,8 +1078,6 @@ Resources:
                           Value: init_table                          
                         - Name: DB_USER_SECRET_NAME
                           Value: !Ref DatabaseUserSecretCanvas
-                        - Name: DB_SCHEMA
-                          Value: !Ref DatabaseSchemaParameter
                   TimeoutSeconds: 43200
                   Retry:
                     - ErrorEquals:
@@ -1308,8 +1299,3 @@ Outputs:
     Description: The ARN of the Canvas Data 2 Aurora cluster
     Export:
       Name: !Sub ${ResourcePrefixParameter}-cd2-aurora-cluster-arn-${EnvironmentParameter}
-  DatabaseSchema:
-    Value: !Ref DatabaseSchemaParameter
-    Description: Target schema for CD2 data
-    Export:
-      Name: !Sub ${ResourcePrefixParameter}-cd2-schema-${EnvironmentParameter}

--- a/template.yaml
+++ b/template.yaml
@@ -55,6 +55,11 @@ Parameters:
     Type: String
     Description: Username for the canvas database user.
 
+  DatabaseSchemaParameter:
+    Type: String
+    Description: Target schema for CD2 data.
+    Default: canvas
+
   DatabaseMinCapacityParameter:
     Type: Number
     Description: Serverless Aurora minimum capacity.
@@ -1020,6 +1025,8 @@ Resources:
                           Value: !GetAtt AuroraDatabaseCluster.MasterUserSecret.SecretArn
                         - Name: DB_CLUSTER_ARN
                           Value: !GetAtt AuroraDatabaseCluster.DBClusterArn  
+                        - Name: DB_SCHEMA
+                          Value: !Ref DatabaseSchemaParameter
                   TimeoutSeconds: 43200
                   Retry:
                     - ErrorEquals:
@@ -1078,6 +1085,8 @@ Resources:
                           Value: init_table                          
                         - Name: DB_USER_SECRET_NAME
                           Value: !Ref DatabaseUserSecretCanvas
+                        - Name: DB_SCHEMA
+                          Value: !Ref DatabaseSchemaParameter
                   TimeoutSeconds: 43200
                   Retry:
                     - ErrorEquals:
@@ -1299,3 +1308,8 @@ Outputs:
     Description: The ARN of the Canvas Data 2 Aurora cluster
     Export:
       Name: !Sub ${ResourcePrefixParameter}-cd2-aurora-cluster-arn-${EnvironmentParameter}
+  DatabaseSchema:
+    Value: !Ref DatabaseSchemaParameter
+    Description: Target schema for CD2 data
+    Export:
+      Name: !Sub ${ResourcePrefixParameter}-cd2-schema-${EnvironmentParameter}


### PR DESCRIPTION
This PR is intended to primarily handle the use-case where there's an existing Aurora cluster where CD2 data should be loaded rather than creating a new cluster.

By way of that, it also allows multiple Canvas environments to have their data loaded into the same cluster under different schemas.

Resolves #33 