### PR TITLE
Updated the SemanticVersion for AthenaPostgreSQLConnector with the latest version

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -148,7 +148,7 @@ Parameters:
   AthenaConnectorLambdaNameParameter:
     Type: String
     Description: (Optional) Name of Athena Connector Lambda. Unused if AthenaConnectorParameter is set to false.
-    Default: athena_postgresql_connector_cd2
+    Default: athena_postgresql_connector_cd2_v_2025_46_1
 
   NotificationTopicParameter:
     Type: String


### PR DESCRIPTION
closes ubc/aws#64
