### PR TITLE
Revert the logical ID and resource name for CatalogDataCatalog so it can maintain the original name.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1719,11 +1719,11 @@ Resources:
         - Key: !Sub ${TagNameParameter}
           Value: !Sub ${TagValueParameter}
 
-  CatalogDataCatalogV2:
+  CatalogDataCatalog:
     Type: AWS::Athena::DataCatalog
     Condition: CreateCatalogAthenaConnector
     Properties:
-      Name: !Sub ${DatabaseCd2UserParameter}_v2
+      Name: !Sub ${DatabaseCd2UserParameter}
       ConnectionType: POSTGRESQL
       Description: PostgreSQL connector to cd2 catalog
       Type: LAMBDA


### PR DESCRIPTION
This is the 2nd change that needed to rename the `catalog` data catalog.